### PR TITLE
defconfig: Fix paths

### DIFF
--- a/update_defconfig.sh
+++ b/update_defconfig.sh
@@ -1,4 +1,5 @@
-export ANDROID_ROOT=../../../../../../../..
+cd ../../../../../../../..
+export ANDROID_ROOT=$(pwd)
 export KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-4.9
 export KERNEL_CFG=arch/arm64/configs/sony
 export KERNEL_TMP=$ANDROID_ROOT/out/kernel-tmp
@@ -34,9 +35,18 @@ tama)
 esac
 
 for device in $DEVICE; do \
-    rm -r $KERNEL_TMP
+    rm -rf $KERNEL_TMP
+    mkdir -p $KERNEL_TMP
     ARCH=arm64 O=$KERNEL_TMP scripts/kconfig/merge_config.sh $KERNEL_CFG/base_$platform"_"$device\_defconfig $KERNEL_CFG/android-base.config $KERNEL_CFG/android-base-arm64.config $KERNEL_CFG/android-recommended.config $KERNEL_CFG/android-extra.config
     $BUILD savedefconfig
     mv $KERNEL_TMP/defconfig ./arch/arm64/configs/aosp_$platform"_"$device\_defconfig
 done
 done
+
+make mrproper
+rm -rf $KERNEL_TMP
+unset ANDROID_ROOT
+unset KERNEL_TOP
+unset KERNEL_CFG
+unset KERNEL_TMP
+unset BUILD

--- a/update_defconfig.sh
+++ b/update_defconfig.sh
@@ -37,13 +37,26 @@ esac
 for device in $DEVICE; do \
     rm -rf $KERNEL_TMP
     mkdir -p $KERNEL_TMP
-    ARCH=arm64 O=$KERNEL_TMP scripts/kconfig/merge_config.sh $KERNEL_CFG/base_$platform"_"$device\_defconfig $KERNEL_CFG/android-base.config $KERNEL_CFG/android-base-arm64.config $KERNEL_CFG/android-recommended.config $KERNEL_CFG/android-extra.config
-    $BUILD savedefconfig
+    echo "================================================="
+    echo "Platform -> ${platform} :: Device -> $device"
+    echo "Running scripts/kconfig/merge_config.sh ..."
+    ret=$(ARCH=arm64 O=${KERNEL_TMP} scripts/kconfig/merge_config.sh ${KERNEL_CFG}/base_${platform}"_"${device}\_defconfig ${KERNEL_CFG}/android-base.config ${KERNEL_CFG}/android-base-arm64.config ${KERNEL_CFG}/android-recommended.config ${KERNEL_CFG}/android-extra.config 2>&1);
+    case "$ret" in  
+        *"error"*|*"ERROR"*) echo "ERROR: $ret"; exit 1;; 
+    esac
+    echo "Building new defconfig ..."
+    ret=$(${BUILD} savedefconfig 2>&1);
+    case "$ret" in  
+        *"error"*|*"ERROR"*) echo "ERROR: $ret"; exit 1;; 
+    esac
     mv $KERNEL_TMP/defconfig ./arch/arm64/configs/aosp_$platform"_"$device\_defconfig
 done
 done
 
-make mrproper
+echo "================================================="
+echo "Clean up environment"
+ret=$(make mrproper 2>&1)
+echo "Done!"
 rm -rf $KERNEL_TMP
 unset ANDROID_ROOT
 unset KERNEL_TOP


### PR DESCRIPTION
Do not use relative path as a value for ANDROID_ROOT.
Force $KERNEL_TMP create/remove.

Change-Id: Ife936810ad6230d289c11e8f4b7c2c4ce1ab267e
Signed-off-by: Humberto Borba <humberos@omnirom.org>