### PR TITLE
[LA.UM.7.1.r1] Cope with the non-existence of some of the config files

### DIFF
--- a/update_defconfig.sh
+++ b/update_defconfig.sh
@@ -88,10 +88,8 @@ for device in $DEVICE; do \
         ${KERNEL_CFG}/base_${platform}"_"${device}\_defconfig \
         ${KERNEL_CFG}/android-extra.config 2>&1);
 
-
-
     case "$ret" in
-        *"error"*|*"ERROR"*) echo "ERROR: $ret"; exit 1;;
+        *"error"*|*"ERROR"*|*"Exit"*) echo "ERROR: $ret"; exit 1;;
     esac
     echo "Building new defconfig ..."
     ret=$(${BUILD} savedefconfig 2>&1);


### PR DESCRIPTION
In my testing I run into this, which wasn't caught properly:

```
. . .
Merging arch/arm64/configs/sony/android-extra.config
The merge file 'arch/arm64/configs/sony/android-extra.config' does not exist.  Exit
```