### PR TITLE
[aosp/LA.UM.9.14.r1] update_defconfig: Set proper output directory for `merge_config.sh`

### DIFF
--- a/update_defconfig.sh
+++ b/update_defconfig.sh
@@ -52,7 +52,8 @@ for device in $DEVICE; do \
     echo "================================================="
     echo "SOC -> ${SOC} :: Platform -> ${platform} :: Device -> $device"
     echo "Running scripts/kconfig/merge_config.sh ..."
-    ret=$(ARCH=arm64 O=${KERNEL_TMP} scripts/kconfig/merge_config.sh \
+    ret=$(ARCH=arm64 scripts/kconfig/merge_config.sh \
+        -O "${KERNEL_TMP}" \
         ${KERNEL_CFG}/android-base.config \
         ${KERNEL_CFG}/android-recommended.config \
         ${KERNEL_CFG}/android-recommended-arm64.config \
@@ -75,8 +76,6 @@ done
 done
 
 echo "================================================="
-echo "Clean up environment"
-ret=$(make mrproper 2>&1)
 echo "Done!"
 rm -rf $KERNEL_TMP
 


### PR DESCRIPTION
`merge_defconfig.sh` does not (appear to?) listen to the `O` environment variable (anymore?), instead using and contaminating the source tree, subsequently failing `savedefconfig` which _does_ use the right output tree but expects the source tree to be pristine:

    Building new defconfig ...
    make[1]: Entering directory 'AOSP/out/kernel-defconfig'
    ***
    *** The source tree is not clean, please run 'make ARCH=arm64 mrproper'
    *** in AOSP/kernel/sony/msm-5.4/kernel
    ***
    make[1]: *** [AOSP/kernel/sony/msm-5.4/kernel/Makefile:538: outputmakefile] Error 1
    make[1]: Leaving directory 'AOSP/out/kernel-defconfig'
    make: *** [Makefile:179: sub-make] Error 2

Solve this by passing the desired output dir through `-O` instead, which is how `merge_defconfig.sh` expects it to be set.  Since the source tree is now finally left untouched, an unnecessary `mrproper` pass is removed too.

---

@jerpelea perhaps this needs to be picked to our 4.19 and 4.14 script? Do those have a `mrproper` pass too?
