### PR TITLE
[2.0.r1] savedefconfig_to_baseconfig: Consolidate filtering into a single grep

### DIFF
--- a/savedefconfig_to_baseconfig.sh
+++ b/savedefconfig_to_baseconfig.sh
@@ -1,15 +1,18 @@
 if [ -z "$1" ] || [ -z "$2" ]
     then
         echo "Usage: ./savedefconfig_to_baseconfig.sh defconfig output_name"
-	exit 1
+    exit 1
 fi
 
 echo "Processing file: $1"
 echo "Output file: $2"
 
 if [ -f "$1" ]; then
-    grep -vf android-base.config $1 > $2 && \
-    grep -vf gki_defconfig $1 > $2 && \
+    grep -v \
+        -f android-base.config \
+        -f gki_defconfig \
+        -f $(basename "$1" | sed 's/aosp_/base_/g') \
+        $1 > $2 && \
     echo "$2 is ready!"
 else
     echo "File '$1' does not exist."


### PR DESCRIPTION
Enhance the filtering process in the script by replacing multiple individual grep commands with a single grep command (otherwise we would need to use a temporary proxy file).

Additionally, include the base_${platform}_defconfig file in the filtering in order to exclude duplicates from it and completely automate the process. The file name is determined dynamically based on the value of the $1 variable. The possible file path is removed and the prefix is changed from aosp_ to base_.

This change ensures that the resulting filtered content in '$2' includes exclusions from 'android-base.config', 'gki_defconfig', and 'base_(nagara/yodo)_defconfig'.