### PR TITLE
[2.0.r1] Add support for Android root autodetection

### DIFF
--- a/update_defconfig.sh
+++ b/update_defconfig.sh
@@ -26,6 +26,20 @@ KERNEL_CFG=arch/arm64/configs/sony
 KERNEL_TMP=$ANDROID_ROOT/out/kernel-tmp
 BUILD="make O=$KERNEL_TMP ARCH=arm64 LLVM=1 CROSS_COMPILE=aarch64-linux-gnu- -j$(nproc)"
 
+echo "================================================="
+echo "Your Environment:"
+echo "ANDROID_ROOT: ${ANDROID_ROOT}"
+echo "KERNEL_TOP  : ${KERNEL_TOP}"
+echo "KERNEL_CFG  : ${KERNEL_CFG}"
+echo "KERNEL_TMP  : ${KERNEL_TMP}"
+ret=$(rm -rf ${KERNEL_TMP} 2>&1);
+ret=$(mkdir -p ${KERNEL_TMP} 2>&1);
+if [ ! -d ${KERNEL_TMP} ] ; then
+    echo "Check your environment";
+    echo "ERROR: ${ret}";
+    exit 1;
+fi
+
 cd $KERNEL_TOP/kernel
 
 # These values must be changed for forks!
@@ -42,7 +56,6 @@ HEAD of the project used to prepare this commit:
 ${KERNEL_DEFCONFIG_URL}/tree/${KERNEL_DEFCONFIG_HEAD}
 EOM
 
-
 PLATFORMS="nagara yodo"
 
 for platform in $PLATFORMS; do \
@@ -55,19 +68,6 @@ for platform in $PLATFORMS; do \
 
     esac
 
-    echo "================================================="
-    echo "Your Environment:"
-    echo "ANDROID_ROOT: ${ANDROID_ROOT}"
-    echo "KERNEL_TOP  : ${KERNEL_TOP}"
-    echo "KERNEL_CFG  : ${KERNEL_CFG}"
-    echo "KERNEL_TMP  : ${KERNEL_TMP}"
-    ret=$(rm -rf ${KERNEL_TMP} 2>&1);
-    ret=$(mkdir -p ${KERNEL_TMP} 2>&1);
-    if [ ! -d ${KERNEL_TMP} ] ; then
-        echo "Check your environment";
-        echo "ERROR: ${ret}";
-        exit 1;
-    fi
     echo "================================================="
     echo "SOC -> ${SOC} :: Platform -> ${platform}"
     echo "Running scripts/kconfig/merge_config.sh ..."

--- a/update_defconfig.sh
+++ b/update_defconfig.sh
@@ -1,11 +1,30 @@
-cd ../../../../../../../..
-ls
-export ANDROID_ROOT=$(pwd)
-export KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.15/
-export KERNEL_CFG=arch/arm64/configs/sony
-export KERNEL_TMP=$ANDROID_ROOT/out/kernel-tmp
-export CROSS_COMPILE=aarch64-linux-gnu-
-export BUILD="make O=$KERNEL_TMP ARCH=arm64 LLVM=1 CROSS_COMPILE=$CROSS_COMPILE -j$(nproc)"
+find_build_top() {
+    local dir=$PWD
+    local max_depth=10
+    while [ $max_depth -gt 0 ]; do
+        if [ -e "$dir/.repo" ]; then
+            realpath "$dir"
+            return 0
+        fi
+        dir=$(dirname "$dir")
+        max_depth=$((max_depth - 1))
+    done
+    return 1
+}
+
+if [ -z "$ANDROID_BUILD_TOP" ]; then
+    if ! ANDROID_ROOT=$(find_build_top); then
+        echo "Error: Could not find the Android root (no .repo found)" >&2
+        exit 1
+    fi
+else
+    ANDROID_ROOT=$(realpath "$ANDROID_BUILD_TOP")
+fi
+
+KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-5.15/
+KERNEL_CFG=arch/arm64/configs/sony
+KERNEL_TMP=$ANDROID_ROOT/out/kernel-tmp
+BUILD="make O=$KERNEL_TMP ARCH=arm64 LLVM=1 CROSS_COMPILE=aarch64-linux-gnu- -j$(nproc)"
 
 cd $KERNEL_TOP/kernel
 
@@ -76,9 +95,3 @@ rm -rf $KERNEL_TMP
 
 echo "You can now commit the updated defconfig with the following as the commit message:"
 echo "${KERNEL_COMMIT_MESSAGE}"
-
-unset ANDROID_ROOT
-unset KERNEL_TOP
-unset KERNEL_CFG
-unset KERNEL_TMP
-unset BUILD


### PR DESCRIPTION
This change allows the script to be run from any directory,
not just the one in which the script is located.